### PR TITLE
OMC option --frontendInline not needed

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -79,7 +79,7 @@ function main(;
     @info "Starting OMC session ($(omc_exe))..."
     omc = OMJulia.OMCSession(omc_exe)
 
-    omc_options = "--baseModelica --frontendInline --baseModelicaOptions=$(bm_options) -d=evaluateAllParameters"
+    omc_options = "--baseModelica --baseModelicaOptions=$(bm_options) -d=evaluateAllParameters"
     omc_version = "unknown"
     results = ModelResult[]
     try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,7 +115,7 @@ const TEST_OMC   = get(ENV, "OMC_EXE", "omc")
 
     omc = OMJulia.OMCSession(TEST_OMC)
     try
-        OMJulia.sendExpression(omc, """setCommandLineOptions("--baseModelica --frontendInline --baseModelicaOptions=scalarize -d=evaluateAllParameters")""")
+        OMJulia.sendExpression(omc, """setCommandLineOptions("--baseModelica --baseModelicaOptions=scalarize,moveBindings -d=evaluateAllParameters")""")
         ok = OMJulia.sendExpression(omc, """loadModel(Modelica, {"4.1.0"})""")
         @test ok == true
 


### PR DESCRIPTION
## Changes

- After [OpenModelica/OpenModelica #15125](https://github.com/OpenModelica/OpenModelica/issues/15125) compiler option `--frontendInline` is no longer needed.