### PR TITLE
Redirect Julia warnings to log files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ authors = ["AnHeuermann"]
 BaseModelica = "a17d5099-185d-4ff5-b5d3-51aa4569e56d"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 OMJulia = "0f4fe800-344e-11e9-2949-fb537ad918e1"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/parse_bm.jl
+++ b/src/parse_bm.jl
@@ -1,6 +1,7 @@
 # ── Phase 2: Base Modelica parsing with BaseModelica.jl ───────────────────────
 
 import BaseModelica
+import Logging
 
 """
     run_parse(bm_path, model_dir, model) → (success, time, error, ode_prob)
@@ -17,24 +18,28 @@ function run_parse(bm_path::String, model_dir::String,
     parse_error   = ""
     ode_prob      = nothing
 
+    log_file = open(joinpath(model_dir, "$(model)_parsing.log"), "w")
+    println(log_file, "Model:   $model")
+    logger = Logging.SimpleLogger(log_file, Logging.Debug)
     t0 = time()
     try
         # create_odeproblem returns an ODEProblem using the Experiment
         # annotation for StartTime/StopTime/Tolerance/Interval.
-        ode_prob      = BaseModelica.create_odeproblem(bm_path)
+        # Redirect all library log output (including Symbolics warnings)
+        # to the log file so they don't clutter stdout.
+        ode_prob      = Logging.with_logger(logger) do
+            BaseModelica.create_odeproblem(bm_path)
+        end
         parse_time    = time() - t0
         parse_success = true
     catch e
         parse_time  = time() - t0
         parse_error = sprint(showerror, e, catch_backtrace())
     end
-
-    open(joinpath(model_dir, "$(model)_parsing.log"), "w") do f
-        println(f, "Model:   $model")
-        println(f, "Time:    $(round(parse_time; digits=3)) s")
-        println(f, "Success: $parse_success")
-        isempty(parse_error) || println(f, "\n--- Error ---\n$parse_error")
-    end
+    println(log_file, "Time:    $(round(parse_time; digits=3)) s")
+    println(log_file, "Success: $parse_success")
+    isempty(parse_error) || println(log_file, "\n--- Error ---\n$parse_error")
+    close(log_file)
 
     return parse_success, parse_time, parse_error, ode_prob
 end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -1,6 +1,7 @@
 # ── Phase 3: ODE simulation with DifferentialEquations / MTK ──────────────────
 
 import DifferentialEquations: solve, Rodas5P, ReturnCode
+import Logging
 import ModelingToolkit
 import Printf: @sprintf
 
@@ -19,10 +20,17 @@ function run_simulate(ode_prob, model_dir::String,
     sim_error   = ""
     sol         = nothing
 
+    log_file = open(joinpath(model_dir, "$(model)_sim.log"), "w")
+    println(log_file, "Model:   $model")
+    logger = Logging.SimpleLogger(log_file, Logging.Debug)
     t0 = time()
     try
         # Rodas5P handles stiff DAE-like systems well.
-        sol      = solve(ode_prob, Rodas5P())
+        # Redirect all library log output (including Symbolics/MTK warnings)
+        # to the log file so they don't clutter stdout.
+        sol = Logging.with_logger(logger) do
+            solve(ode_prob, Rodas5P())
+        end
         sim_time = time() - t0
         if sol.retcode == ReturnCode.Success
             sim_success = true
@@ -33,13 +41,10 @@ function run_simulate(ode_prob, model_dir::String,
         sim_time  = time() - t0
         sim_error = sprint(showerror, e, catch_backtrace())
     end
-
-    open(joinpath(model_dir, "$(model)_sim.log"), "w") do f
-        println(f, "Model:   $model")
-        println(f, "Time:    $(round(sim_time; digits=3)) s")
-        println(f, "Success: $sim_success")
-        isempty(sim_error) || println(f, "\n--- Error ---\n$sim_error")
-    end
+    println(log_file, "Time:    $(round(sim_time; digits=3)) s")
+    println(log_file, "Success: $sim_success")
+    isempty(sim_error) || println(log_file, "\n--- Error ---\n$sim_error")
+    close(log_file)
 
     # Write simulation results CSV (time + all state variables)
     if sim_success && sol !== nothing


### PR DESCRIPTION
## Changes

Suppress library warnings on stdout; redirect them to per-phase log files

Wrap the BaseModelica.create_odeproblem and DifferentialEquations.solve calls with Logging.with_logger(SimpleLogger(log_file)) so that warnings from Symbolics, MTK, and the solver (e.g. "Did not converge after maxiters substitutions") are captured in the existing _parsing.log / _sim.log files instead of cluttering stdout.